### PR TITLE
Add healthcheck and wait-for-postgres logic in docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,10 +1,10 @@
-version: '3.8'  # Optional - defines Docker Compose file version
+version: '3.8'
 
 services:
   flaskapp:
     build: .
     ports:
-      - "5000:5000"  # Maps host:container port
+      - "5000:5000"
     environment:
       - DATABASE_HOST=postgres
       - DATABASE_PORT=5432
@@ -13,9 +13,10 @@ services:
       - DATABASE_PASSWORD=flaskpass
       - ENCRYPTION_KEY=${ENCRYPTION_KEY}
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
     volumes:
-      - .:/app  # Optional - Mounts local code inside container
+      - .:/app
 
   postgres:
     image: postgres:13
@@ -26,7 +27,12 @@ services:
       - POSTGRES_USER=flaskuser
       - POSTGRES_PASSWORD=flaskpass
     volumes:
-      - pgdata:/var/lib/postgresql/data  # Persist data
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U flaskuser"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
 volumes:
   pgdata:


### PR DESCRIPTION
checked , it is update about  using depends_on with a healthcheck for the postgres service. This ensures that your Flask app waits until Postgres is fully up and healthy before starting.